### PR TITLE
Deck, Note Type, Field Filters

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -11,45 +11,28 @@ class UI(QWidget):
     def __init__(self):
         super().__init__()
         self.parent = mw
-        self.setupMenu()
+        self.setup_menu()
 
-    def setupMenu(self):
+    def setup_menu(self):
         action = QAction("LL", mw)
-        action.triggered.connect(self.showUI)
+        action.triggered.connect(self.render)
         mw.form.menuTools.addAction(action)
 
         # Setup config button
         # mw.addonManager.setConfigAction(addon_id, self.show_config)
 
-    def showUI(self):
-        mainLayout = QVBoxLayout()
+    def render(self):
+        main_layout = QVBoxLayout()
 
         # Layout tabs
         self.tabs = tabs.Tabs()
-        mainLayout.addWidget(self.tabs)
-
-        # Add an horizontal line
-        mainLayout.addWidget(self.hLine())
-
-        # Bottom button(s)
-        closeButton = QPushButton("Done")
-        closeButton.clicked.connect(self.close)
-        btnLayout = QHBoxLayout()
-        btnLayout.addStretch(1)
-        btnLayout.addWidget(closeButton)
-        mainLayout.addLayout(btnLayout)
+        main_layout.addWidget(self.tabs)
 
         # Center the window
         self.move(QDesktopWidget().availableGeometry().center() - self.frameGeometry().center())
 
-        self.setLayout(mainLayout)
+        self.setLayout(main_layout)
         self.setWindowTitle("LL")
         self.show()
         self.raise_()
         self.activateWindow()
-
-    def hLine(self):
-        line = QFrame()
-        line.setFrameShape(QFrame.HLine)
-        line.setFrameShadow(QFrame.Sunken)
-        return line

--- a/views/field_chooser.py
+++ b/views/field_chooser.py
@@ -1,0 +1,79 @@
+from aqt.qt import *
+from anki.hooks import addHook, remHook
+from anki.lang import _
+
+
+class FieldChooser(QHBoxLayout):
+    """
+    Mirrors aqt.modelchooser.ModelChooser, except for a model's fields
+    """
+
+    def __init__(self, mw, widget, label=True):
+        QHBoxLayout.__init__(self)
+        self.widget = widget
+        self.mw = mw
+        self.label = label
+        self.setup_fields_button()
+        self.update_fields()
+        self.setContentsMargins(0, 0, 0, 0)
+        self.setSpacing(8)
+        addHook("reset", self.on_reset)
+        addHook("currentModelChanged", self.update_fields)
+        self.widget.setLayout(self)
+
+    def setup_fields_button(self):
+        if self.label:
+            self.field_label = QLabel(_("Field"))
+            self.addWidget(self.field_label)
+        self.fields = QPushButton()
+        self.fields.setAutoDefault(False)
+        self.addWidget(self.fields)
+        self.fields.clicked.connect(self.on_field_change)
+        # layout
+        sizePolicy = QSizePolicy(
+            QSizePolicy.Policy(7),
+            QSizePolicy.Policy(0))
+        self.fields.setSizePolicy(sizePolicy)
+
+    def cleanup(self):
+        remHook("reset", self.on_reset)
+        remHook("currentModelChanged", self.update_fields)
+
+    def on_reset(self):
+        self.update_fields_button()
+
+    def show(self):
+        self.widget.show()
+
+    def hide(self):
+        self.widget.hide()
+
+    def update_fields(self):
+        """
+        If model changes via modelchooser, reflect appropriate fields in field chooser/button
+        """
+        current_model = self.mw.col.models.current()
+        self.field_names = [field["name"] for field in current_model["flds"]]
+        self.current_field_name = self.field_names[0]
+        self.update_fields_button()
+
+    def on_field_change(self):
+        from aqt.studydeck import StudyDeck
+        placeholder = QPushButton(_("N/A"))
+        # Button created and disabled so that default "Add new deck" button isn't created by StudyDeck
+        placeholder.setEnabled(False)
+        def nameFunc():
+            return sorted(self.field_names)
+        returned_field = StudyDeck(
+            self.mw, names=nameFunc,
+            accept=_("Choose"), title=_("Choose Field"),
+            current=self.current_field_name, parent=self.widget,
+            buttons=[placeholder], cancel=True, geomKey="selectField")
+        if not returned_field.name:
+            return
+        self.current_field_name = returned_field.name
+        self.update_fields_button()
+        self.mw.reset()
+
+    def update_fields_button(self):
+        self.fields.setText(self.current_field_name)

--- a/views/find_missing.py
+++ b/views/find_missing.py
@@ -1,22 +1,83 @@
+from aqt import mw
 from aqt.qt import *
+import aqt.deckchooser
+import aqt.modelchooser
 
 
 class FindMissingWords(QVBoxLayout):
     def __init__(self):
         super().__init__()
+        self.deck_selection_enabled = True
+        self.model_selection_enabled = False
         self.render()
 
     def render(self):
+        self.render_deck_chooser()
+        self.render_model_chooser()
+        self.render_text_area()
+        self.render_search_button()
+
+    def render_text_area(self):
+        self.text_area_label = QLabel()
+        self.text_area_label.setText("Text:")
+        self.addWidget(self.text_area_label)
         self.text = QTextEdit()
         self.addWidget(self.text)
 
+    def render_deck_chooser(self):
+        self.deck_selection_checkbox = QCheckBox("Filter Deck?")
+        self.deck_selection_checkbox.setChecked(self.deck_selection_enabled)
+        self.deck_selection_checkbox.stateChanged.connect(self.toggle_deck_selection)
+
+        self.deck_chooser_parent_widget = QWidget()
+        self.deck_chooser = aqt.deckchooser.DeckChooser(mw, self.deck_chooser_parent_widget)
+        self.deck_chooser_parent_widget.setEnabled(self.deck_selection_enabled)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addWidget(self.deck_selection_checkbox)
+        btn_layout.addStretch(1)
+        btn_layout.addWidget(self.deck_chooser_parent_widget)
+        self.addLayout(btn_layout)
+
+    def render_model_chooser(self):
+        self.model_selection_checkbox = QCheckBox("Filter Model/Note Type?")
+        self.model_selection_checkbox.setChecked(self.model_selection_enabled)
+        self.model_selection_checkbox.stateChanged.connect(self.toggle_model_selection)
+
+        self.model_chooser_parent_widget = QWidget()
+        self.model_chooser = aqt.modelchooser.ModelChooser(mw, self.model_chooser_parent_widget)
+        self.model_chooser_parent_widget.setEnabled(self.model_selection_enabled)
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addWidget(self.model_selection_checkbox)
+        btn_layout.addStretch(1)
+        btn_layout.addWidget(self.model_chooser_parent_widget)
+        self.addLayout(btn_layout)
+
+    def toggle_deck_selection(self):
+        self.deck_selection_enabled = not self.deck_selection_enabled
+        self.deck_chooser_parent_widget.setEnabled(self.deck_selection_enabled)
+
+    def toggle_model_selection(self):
+        self.model_selection_enabled = not self.model_selection_enabled
+        self.model_chooser_parent_widget.setEnabled(self.model_selection_enabled)
+
+    def render_search_button(self):
         self.search_button = QPushButton("Search")
         self.search_button.clicked.connect(self.search)
-        btnLayout = QHBoxLayout()
-        btnLayout.addStretch(1)
-        btnLayout.addWidget(self.search_button)
-        self.addLayout(btnLayout)
+        btn_layout = QHBoxLayout()
+        btn_layout.addStretch(1)
+        btn_layout.addWidget(self.search_button)
+        self.addLayout(btn_layout)
 
     def search(self):
         # Search through fetched cards here
-        pass
+        deck_id = self.deck_chooser.selectedId()
+        self.deck_label = QLabel()
+        self.deck_label.setText(str(deck_id))
+        self.addWidget(self.deck_label)
+
+        # model_id = self.model_chooser.selectedId()
+        # self.model_label = QLabel()
+        # self.model_label.setText(str(model_id))
+        # self.addWidget(self.model_label)

--- a/views/find_missing.py
+++ b/views/find_missing.py
@@ -1,7 +1,11 @@
+from functools import partial
+
 from aqt import mw
 from aqt.qt import *
 import aqt.deckchooser
 import aqt.modelchooser
+
+from . import field_chooser
 
 
 class FindMissingWords(QVBoxLayout):
@@ -9,58 +13,50 @@ class FindMissingWords(QVBoxLayout):
         super().__init__()
         self.deck_selection_enabled = True
         self.model_selection_enabled = False
+        self.field_selection_enabled = False
         self.render()
 
     def render(self):
-        self.render_deck_chooser()
-        self.render_model_chooser()
+        self.deck_chooser = self.render_filter("Filter deck?", self.deck_selection_enabled, self.toggle_deck_selection, aqt.deckchooser.DeckChooser)
+        self.model_chooser = self.render_filter("Filter model/note type?", self.model_selection_enabled, self.toggle_model_selection, aqt.modelchooser.ModelChooser)
+        self.field_chooser = self.render_filter("Filter field?", self.field_selection_enabled, self.toggle_field_selection, field_chooser.FieldChooser)
         self.render_text_area()
         self.render_search_button()
+
+    def render_filter(self, checkbox_label, state, on_state_change, chooser_class):
+        checkbox = QCheckBox(checkbox_label)
+        checkbox.setChecked(state)
+
+        chooser_widget = QWidget()
+        chooser = chooser_class(mw, chooser_widget)
+        chooser_widget.setEnabled(state)
+        checkbox.stateChanged.connect(partial(on_state_change, chooser_widget))
+
+        btn_layout = QHBoxLayout()
+        btn_layout.addWidget(checkbox)
+        btn_layout.addStretch(1)
+        btn_layout.addWidget(chooser_widget)
+        self.addLayout(btn_layout)
+        return chooser
+
+    def toggle_deck_selection(self, parent_widget):
+        self.deck_selection_enabled = not self.deck_selection_enabled
+        parent_widget.setEnabled(self.deck_selection_enabled)
+
+    def toggle_model_selection(self, parent_widget):
+        self.model_selection_enabled = not self.model_selection_enabled
+        parent_widget.setEnabled(self.model_selection_enabled)
+
+    def toggle_field_selection(self, parent_widget):
+        self.field_selection_enabled = not self.field_selection_enabled
+        parent_widget.setEnabled(self.field_selection_enabled)
 
     def render_text_area(self):
         self.text_area_label = QLabel()
         self.text_area_label.setText("Text:")
         self.addWidget(self.text_area_label)
-        self.text = QTextEdit()
-        self.addWidget(self.text)
-
-    def render_deck_chooser(self):
-        self.deck_selection_checkbox = QCheckBox("Filter Deck?")
-        self.deck_selection_checkbox.setChecked(self.deck_selection_enabled)
-        self.deck_selection_checkbox.stateChanged.connect(self.toggle_deck_selection)
-
-        self.deck_chooser_parent_widget = QWidget()
-        self.deck_chooser = aqt.deckchooser.DeckChooser(mw, self.deck_chooser_parent_widget)
-        self.deck_chooser_parent_widget.setEnabled(self.deck_selection_enabled)
-
-        btn_layout = QHBoxLayout()
-        btn_layout.addWidget(self.deck_selection_checkbox)
-        btn_layout.addStretch(1)
-        btn_layout.addWidget(self.deck_chooser_parent_widget)
-        self.addLayout(btn_layout)
-
-    def render_model_chooser(self):
-        self.model_selection_checkbox = QCheckBox("Filter Model/Note Type?")
-        self.model_selection_checkbox.setChecked(self.model_selection_enabled)
-        self.model_selection_checkbox.stateChanged.connect(self.toggle_model_selection)
-
-        self.model_chooser_parent_widget = QWidget()
-        self.model_chooser = aqt.modelchooser.ModelChooser(mw, self.model_chooser_parent_widget)
-        self.model_chooser_parent_widget.setEnabled(self.model_selection_enabled)
-
-        btn_layout = QHBoxLayout()
-        btn_layout.addWidget(self.model_selection_checkbox)
-        btn_layout.addStretch(1)
-        btn_layout.addWidget(self.model_chooser_parent_widget)
-        self.addLayout(btn_layout)
-
-    def toggle_deck_selection(self):
-        self.deck_selection_enabled = not self.deck_selection_enabled
-        self.deck_chooser_parent_widget.setEnabled(self.deck_selection_enabled)
-
-    def toggle_model_selection(self):
-        self.model_selection_enabled = not self.model_selection_enabled
-        self.model_chooser_parent_widget.setEnabled(self.model_selection_enabled)
+        self.text_area_text = QTextEdit()
+        self.addWidget(self.text_area_text)
 
     def render_search_button(self):
         self.search_button = QPushButton("Search")
@@ -72,12 +68,8 @@ class FindMissingWords(QVBoxLayout):
 
     def search(self):
         # Search through fetched cards here
-        deck_id = self.deck_chooser.selectedId()
-        self.deck_label = QLabel()
-        self.deck_label.setText(str(deck_id))
-        self.addWidget(self.deck_label)
+        deck_id = self.deck_selection_enabled and self.deck_chooser.selectedId()
+        deck_name = self.deck_selection_enabled and self.deck_chooser.deckName()
+        model_name = self.model_selection_enabled and mw.col.models.current()['name']
+        field_name = self.field_selection_enabled and self.field_chooser.current_field_name
 
-        # model_id = self.model_chooser.selectedId()
-        # self.model_label = QLabel()
-        # self.model_label.setText(str(model_id))
-        # self.addWidget(self.model_label)

--- a/views/tabs.py
+++ b/views/tabs.py
@@ -9,8 +9,8 @@ class Tabs(QTabWidget):
         self.render()
 
     def render(self):
-        self.tab1 = QWidget()
-        self.addTab(self.tab1, "Find Missing Words")
+        self.tab_1 = QWidget()
+        self.addTab(self.tab_1, "Find Missing Words")
         self.setTabText(0, "Find Missing Words")
         find_missing_layout = find_missing.FindMissingWords()
-        self.tab1.setLayout(find_missing_layout)
+        self.tab_1.setLayout(find_missing_layout)


### PR DESCRIPTION
Added checkboxes and choosers to filter by deck, model (note type), and field.

Choosers were already made available by Anki for deck and model selection, but not field. I mirrored
the other two in our own `fieldchooser.py`.

Updating the model will update the available fields. Updating deck doesn't affect anything else since they can have multiple models.

The choices are made available in the `search()` method in `find_missing.py`.

[Video Demo](https://i.imgur.com/HuFByaY.mp4)

P.S.

- Converted camelcase to standard snake case
- Removed unnecessary bottom buttons on main addon window