### PR TITLE
Overhaul Word Select Pane

### DIFF
--- a/designer/note_creation.ui
+++ b/designer/note_creation.ui
@@ -61,7 +61,7 @@
                <string notr="true">background-color: lightgreen</string>
               </property>
               <property name="text">
-               <string>New</string>
+               <string> New </string>
               </property>
              </widget>
             </item>
@@ -77,7 +77,7 @@
                <string notr="true">background-color: lightgreen</string>
               </property>
               <property name="text">
-               <string>Words</string>
+               <string> Words </string>
               </property>
              </widget>
             </item>

--- a/designer/note_creation.ui
+++ b/designer/note_creation.ui
@@ -35,10 +35,53 @@
          </property>
          <layout class="QVBoxLayout" name="verticalLayout_2">
           <item>
-           <layout class="QHBoxLayout" name="key_known_words_hbox"/>
+           <widget class="QLabel" name="label_2">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Known words</string>
+            </property>
+           </widget>
           </item>
           <item>
-           <layout class="QHBoxLayout" name="key_new_words_hbox"/>
+           <layout class="QHBoxLayout" name="key_new_words_hbox">
+            <item>
+             <widget class="QLabel" name="label_3">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">background-color: lightgreen</string>
+              </property>
+              <property name="text">
+               <string>New</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="label_4">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="styleSheet">
+               <string notr="true">background-color: lightgreen</string>
+              </property>
+              <property name="text">
+               <string>Words</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>

--- a/src/find_missing_words/config.json
+++ b/src/find_missing_words/config.json
@@ -3,7 +3,7 @@
   "filter_on_note_fields": false,
   "default_deck": "",
   "default_notes_and_fields": [],
-  "ignored_words": ["!", "\"", "#", "$", "%", "&", "'", "(", ")", "*", "+", ",", "-", ".", "/", ":", ";", "<", "=", ">", "?", "@", "[", "\\", "]", "^", "_", "`", "{", "|", "}", "~"],
+  "ignored_words": [],
   "previous_filters": [],
   "note_creation_presets": {}
 }

--- a/src/find_missing_words/gui/search.py
+++ b/src/find_missing_words/gui/search.py
@@ -4,8 +4,6 @@ First view of the addon: search
 Enter search queries and filter by decks, note types, and fields
 """
 
-import re
-
 from aqt import mw, deckchooser
 from aqt.qt import *
 from anki.hooks import addHook, remHook
@@ -128,17 +126,20 @@ class Search(QDialog):
             note_creation_window.show()
         else:
             self.note_creation_window.word_select.set_word_model(word_model)
-            self.note_creation_window.word_select.reset()
+            self.note_creation_window.word_select.build()
 
     def build_word_model(self, text):
         word_model = {}
-        tokens = re.findall(utils.token_regex, text)
+        tokens = utils.split_words(text)
         for token in tokens:
+            if not utils.is_word(token):
+                continue
             query = self.get_final_search(token)
             found_note_ids = mw.col.findNotes(query)
             config = mw.addonManager.getConfig(__name__)
             ignored_words = config[ConfigProperties.IGNORED_WORDS.value]
-            known = len(found_note_ids) > 0 or token.lower() in [ignored_word.lower() for ignored_word in ignored_words]
+            is_word = utils.is_word(token)
+            known = len(found_note_ids) > 0 or token.lower() in [ignored_word.lower() for ignored_word in ignored_words] or not is_word
             word_model[token] = {
                 "note_ids": found_note_ids,
                 "known": known

--- a/src/find_missing_words/gui/search.py
+++ b/src/find_missing_words/gui/search.py
@@ -129,6 +129,11 @@ class Search(QDialog):
             self.note_creation_window.word_select.build()
 
     def build_word_model(self, text):
+        """
+        Create map of words to the note ids that contain the word and filter out known words
+        @param text: input text to tokenize and search on
+        """
+        
         word_model = {}
         tokens = utils.split_words(text)
         for token in tokens:
@@ -138,8 +143,7 @@ class Search(QDialog):
             found_note_ids = mw.col.findNotes(query)
             config = mw.addonManager.getConfig(__name__)
             ignored_words = config[ConfigProperties.IGNORED_WORDS.value]
-            is_word = utils.is_word(token)
-            known = len(found_note_ids) > 0 or token.lower() in [ignored_word.lower() for ignored_word in ignored_words] or not is_word
+            known = len(found_note_ids) > 0 or token.lower() in [ignored_word.lower() for ignored_word in ignored_words]
             word_model[token] = {
                 "note_ids": found_note_ids,
                 "known": known

--- a/src/find_missing_words/gui/search.py
+++ b/src/find_missing_words/gui/search.py
@@ -131,7 +131,7 @@ class Search(QDialog):
     def build_word_model(self, text):
         """
         Create map of words to the note ids that contain the word and filter out known words
-        @param text: input text to tokenize and search on
+        :param text: input text to tokenize and search on
         """
         
         word_model = {}

--- a/src/find_missing_words/gui/search_results/add_note_widget.py
+++ b/src/find_missing_words/gui/search_results/add_note_widget.py
@@ -30,7 +30,6 @@ class AddNoteWidget(QWidget):
         self.history = []
         addHook('reset', self.onReset)
         addHook('currentModelChanged', self.onModelChange)
-        addCloseShortcut(self)
         self.show()
 
     def setupEditor(self):

--- a/src/find_missing_words/gui/search_results/note_creation.py
+++ b/src/find_missing_words/gui/search_results/note_creation.py
@@ -73,17 +73,6 @@ class NoteCreation(QDialog):
         """
         self.word_select = word_select_widget = word_select.WordSelect(self.text, self.word_model, parent=self)
         self.form.word_select_pane_vbox.addWidget(word_select_widget)
-        self.render_word_select_key()
-
-    def render_word_select_key(self):
-        known_word_bubble_1 = word_select.Bubble("Known", True)
-        known_word_bubble_2 = word_select.Bubble("Words", True)
-        self.form.key_known_words_hbox.addWidget(known_word_bubble_1)
-        self.form.key_known_words_hbox.addWidget(known_word_bubble_2)
-        new_word_bubble_1 = word_select.Bubble("New", False)
-        new_word_bubble_2 = word_select.Bubble("Words", False)
-        self.form.key_new_words_hbox.addWidget(new_word_bubble_1)
-        self.form.key_new_words_hbox.addWidget(new_word_bubble_2)
 
     def load_word(self, word, note_ids, known):
         self.reset_list()

--- a/src/find_missing_words/gui/search_results/word_select.py
+++ b/src/find_missing_words/gui/search_results/word_select.py
@@ -10,6 +10,11 @@ from .. import utils
 
 
 class WordSelect(QTextBrowser):
+    """
+    Text browser that accepts a string and a word model that defines what should be highlighted.
+    Highlighting done via CSS.
+    """
+    
     STYLE = """
     body {
         line-height: 1.5;
@@ -36,6 +41,14 @@ class WordSelect(QTextBrowser):
         self.setText(self.html)
 
     def build_html(self):
+        """
+        Build the html which includes the stylesheet and the text.
+        Use anchor <a> tags for new words.
+        Use classname for CSS targeting/coloring and use href attr. for word string.
+        On <a> link click, look at link's href to determine word clicked on.
+        Somewhat of a hack, but also very simple.
+        """
+        
         html = "<html><head><style type='text/css'>" + WordSelect.STYLE + "</style></head><body>"
         tokens = utils.split_words(self.text)
         for token in tokens:
@@ -55,12 +68,20 @@ class WordSelect(QTextBrowser):
         self.word_model = word_model
 
     def intercept_click(self, link):
+        """
+        Listen for anchor <a> tag click, get word by looking at the href value.
+        """
+
         word = link.toString()
         note_ids = self.word_model[word]["note_ids"]
         known = self.word_model[word]["known"]
         runHook("load_word", word, note_ids, known)
 
     def ignore_word(self, word):
+        """
+        Ignore word by changing the data model and re-rendering the html.
+        """
+
         for token in self.word_model:
             if token.lower() == word.lower():
                 self.word_model[token]["known"] = True

--- a/src/find_missing_words/gui/search_results/word_select.py
+++ b/src/find_missing_words/gui/search_results/word_select.py
@@ -19,7 +19,7 @@ class WordSelect(QTextBrowser):
     
     STYLE = """
     body {
-        font-size: 13px;
+        font-size: 11pt;
         line-height: 1.5;
     }
     a {

--- a/src/find_missing_words/gui/search_results/word_select.py
+++ b/src/find_missing_words/gui/search_results/word_select.py
@@ -3,205 +3,65 @@ Module for the word select pane displayed on the left side of the search results
 Displays the text from the search window and highlights the words not found in the search query.
 """
 
-import re
-
 from aqt.qt import *
 from anki.hooks import runHook
 
 from .. import utils
 
 
-class FlowLayout(QLayout):
+class WordSelect(QTextBrowser):
+    STYLE = """
+    body {
+        line-height: 1.5;
+    }
+    a {
+        color: black;
+        text-decoration: none !important;
+    }
+    .unknown {
+        background: lightgreen;
+    }
     """
-    Responsive layout for the words
-    """
-    def __init__(self, parent=None, margin=-1, hspacing=-1, vspacing=-1):
-        super().__init__(parent)
-        self._hspacing = hspacing
-        self._vspacing = vspacing
-        self._items = []
-        self.setContentsMargins(margin, margin, margin, margin)
 
-    def clear(self):
-        utils.clear_layout(self)
-
-    def __del__(self):
-        del self._items[:]
-
-    def addItem(self, item):
-        self._items.append(item)
-
-    def horizontalSpacing(self):
-        if self._hspacing >= 0:
-            return self._hspacing
-        return self.smartSpacing(
-            QStyle.PM_LayoutHorizontalSpacing)
-
-    def verticalSpacing(self):
-        if self._vspacing >= 0:
-            return self._vspacing
-        return self.smartSpacing(
-            QStyle.PM_LayoutVerticalSpacing)
-
-    def count(self):
-        return len(self._items)
-
-    def itemAt(self, index):
-        if 0 <= index < len(self._items):
-            return self._items[index]
-
-    def takeAt(self, index):
-        if 0 <= index < len(self._items):
-            return self._items.pop(index)
-
-    def expandingDirections(self):
-        return Qt.Orientations(0)
-
-    def hasHeightForWidth(self):
-        return True
-
-    def heightForWidth(self, width):
-        return self.doLayout(QRect(0, 0, width, 0), True)
-
-    def setGeometry(self, rect):
-        super().setGeometry(rect)
-        self.doLayout(rect, False)
-
-    def sizeHint(self):
-        return self.minimumSize()
-
-    def minimumSize(self):
-        size = QSize()
-        for item in self._items:
-            size = size.expandedTo(item.minimumSize())
-        left, top, right, bottom = self.getContentsMargins()
-        size += QSize(left + right, top + bottom)
-        return size
-
-    def doLayout(self, rect, testonly):
-        left, top, right, bottom = self.getContentsMargins()
-        effective = rect.adjusted(+left, +top, -right, -bottom)
-        x = effective.x()
-        y = effective.y()
-        lineheight = 0
-        for item in self._items:
-            widget = item.widget()
-            hspace = self.horizontalSpacing()
-            if hspace == -1:
-                hspace = widget.style().layoutSpacing(
-                    QSizePolicy.PushButton,
-                    QSizePolicy.PushButton, Qt.Horizontal)
-            vspace = self.verticalSpacing()
-            if vspace == -1:
-                vspace = widget.style().layoutSpacing(
-                    QSizePolicy.PushButton,
-                    QSizePolicy.PushButton, Qt.Vertical)
-            nextX = x + item.sizeHint().width() + hspace
-            if nextX - hspace > effective.right() and lineheight > 0:
-                x = effective.x()
-                y = y + lineheight + vspace
-                nextX = x + item.sizeHint().width() + hspace
-                lineheight = 0
-            if not testonly:
-                item.setGeometry(QRect(QPoint(x, y), item.sizeHint()))
-            x = nextX
-            lineheight = max(lineheight, item.sizeHint().height())
-        return y + lineheight - rect.y() + bottom
-
-    def smartSpacing(self, pm):
-        parent = self.parent()
-        if parent is None:
-            return -1
-        if parent.isWidgetType():
-            return parent.style().pixelMetric(pm, None, parent)
-        return parent.spacing()
-
-
-class Bubble(QLabel):
-    """
-    Word bubble
-    Highlight green if word not known
-    """
-    def __init__(self, word, known):
-        super().__init__(word)
-        self.word = word
-        self.known = known
-        self.setContentsMargins(5, 5, 5, 5)
-        self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Preferred)
-
-    def paintEvent(self, event):
-        painter = QPainter(self)
-        rect = event.rect()
-        painter.eraseRect(rect)
-        painter.setRenderHint(QPainter.Antialiasing, True)
-        self.setStyleSheet("")
-        if not self.known:
-            painter.drawRoundedRect(
-                0, 0, self.width() - 1, self.height() - 1, 5, 5)
-            self.setStyleSheet("background: lightgreen")
-        super().paintEvent(event)
-
-
-class LiveBubble(Bubble):
-    """
-    Word bubble that is functionally active: clickable and runs hooks
-    """
-    def __init__(self, word, known, note_ids):
-        super().__init__(word, known)
-        self.note_ids = note_ids
-        if self.word not in utils.punctuation:
-            self.setCursor(Qt.PointingHandCursor)
-
-    def ignore(self):
-        self.known = True
-
-    def strip_word(self):
-        return self.word.translate(str.maketrans('', '', utils.punctuation))
-
-    def mousePressEvent(self, event):
-        if self.word in utils.punctuation:
-            return
-        word = self.strip_word().lower()
-        runHook("load_word", word, self.note_ids, self.known)
-        super().mousePressEvent(event)
-
-
-class WordSelect(QScrollArea):
     def __init__(self, text, word_model, parent=None):
         super().__init__(parent)
         self.text = text
         self.word_model = word_model
+        self.build()
+        self.setOpenLinks(False)
+        self.anchorClicked.connect(self.intercept_click)
 
-        widget = QWidget(self)
-        widget.setAutoFillBackground(True)
-        self.setWidgetResizable(True)
-        self.setWidget(widget)
+    def build(self):
+        self.html = self.build_html()
+        self.setText(self.html)
 
-        widget.setMinimumWidth(50)
-        self.layout = FlowLayout(widget)
-        self.draw()
+    def build_html(self):
+        html = "<html><head><style type='text/css'>" + WordSelect.STYLE + "</style></head><body>"
+        tokens = utils.split_words(self.text)
+        for token in tokens:
+            if not utils.is_word(token):
+                # Not a word, don't allow clicking
+                html += token
+                continue
+            known = self.word_model[token]["known"]
+            if known:
+                html += f"<a href='{token}'>{token}</a>"
+            else:
+                html += f"<a class='unknown' href='{token}'>{token}</a>"
+        html += "</body></html>"
+        return html
 
     def set_word_model(self, word_model):
         self.word_model = word_model
 
-    def reset(self):
-        self.layout.clear()
-        self.draw()
-
-    def draw(self):
-        self.words = []
-        tokens = re.findall(utils.token_regex, self.text)
-        for token in tokens:
-            known = self.word_model[token]["known"]
-            note_ids = self.word_model[token]["note_ids"]
-            word_bubble = LiveBubble(token, known, note_ids)
-            word_bubble.setFixedWidth(word_bubble.sizeHint().width())
-            self.words.append(word_bubble)
-            self.layout.addWidget(word_bubble)
+    def intercept_click(self, link):
+        word = link.toString()
+        note_ids = self.word_model[word]["note_ids"]
+        known = self.word_model[word]["known"]
+        runHook("load_word", word, note_ids, known)
 
     def ignore_word(self, word):
-        for i in range(self.layout.count()):
-            word_bubble = self.layout.itemAt(i).widget()
-            if word.lower() == word_bubble.text().lower():
-                word_bubble.ignore()
-                word_bubble.update()
+        for token in self.word_model:
+            if token.lower() == word.lower():
+                self.word_model[token]["known"] = True
+        self.build()

--- a/src/find_missing_words/gui/search_results/word_select.py
+++ b/src/find_missing_words/gui/search_results/word_select.py
@@ -3,6 +3,8 @@ Module for the word select pane displayed on the left side of the search results
 Displays the text from the search window and highlights the words not found in the search query.
 """
 
+import re
+
 from aqt.qt import *
 from anki.hooks import runHook
 
@@ -17,6 +19,7 @@ class WordSelect(QTextBrowser):
     
     STYLE = """
     body {
+        font-size: 13px;
         line-height: 1.5;
     }
     a {
@@ -54,13 +57,15 @@ class WordSelect(QTextBrowser):
         for token in tokens:
             if not utils.is_word(token):
                 # Not a word, don't allow clicking
+                # Render double spacing correctly in HTML
+                token = re.sub(r"\n{2,}", "<br><br>", token)
                 html += token
                 continue
             known = self.word_model[token]["known"]
             if known:
                 html += f"<a href='{token}'>{token}</a>"
             else:
-                html += f"<a class='unknown' href='{token}'>{token}</a>"
+                html += f"<a class='unknown' href='{token}'>&nbsp;{token}&nbsp;</a>"
         html += "</body></html>"
         return html
 

--- a/src/find_missing_words/gui/utils/__init__.py
+++ b/src/find_missing_words/gui/utils/__init__.py
@@ -7,6 +7,9 @@ token_regex = r"(\b[^\s]+\b)"
 
 
 def split_words(text):
+    """
+    Split words in a text by word boundary (see above regex pattern)
+    """
     return re.split(token_regex, text)
 
 

--- a/src/find_missing_words/gui/utils/__init__.py
+++ b/src/find_missing_words/gui/utils/__init__.py
@@ -1,10 +1,17 @@
 from . import *
 
 import uuid
-import string
+import re
 
-punctuation = string.punctuation.replace("'", "")
-token_regex = rf"[\w']+|[{punctuation}]"
+token_regex = r"(\b[^\s]+\b)"
+
+
+def split_words(text):
+    return re.split(token_regex, text)
+
+
+def is_word(text):
+    return re.match(token_regex, text)
 
 
 def clear_layout(layout):


### PR DESCRIPTION
Move to QTextBrowser + HTML instead of a QLabel object for each 
word/token. This should decrease resource consumption and make
the text look cleaner. The QLabels with large margins made the text
look less readable.

Use cleaner methods of differentiating actual text from punctuation,
spaces, symbols, etc. The new methods are more correct, as I found
out when trying a longer French text. The apostrophes making the
elisions and hyphenated words are poorly parsed. All of these factors
made the word select look bad, m'kay.

Before:

![](https://i.imgur.com/YGAB9Ps.png)

After: 

![](https://i.imgur.com/naM5zPV.png)

The new look is a bit simpler, but the subset of CSS allowed in Qt stylesheets doesn't allow for more padding. On the plus side, I think it looks/reads more like the original text.

---

P.S. Remove the symbols/punctuation from the default ignored_words in config.
These won't be a problem from now on since they aren't considered in the
model of valid words that are clickable.